### PR TITLE
Add GitHub Actions workflow to test builds

### DIFF
--- a/.github/workflows/testing-workflow.yml
+++ b/.github/workflows/testing-workflow.yml
@@ -1,0 +1,22 @@
+name: Test source code
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: .nvmrc
+        cache: npm
+
+    - name: Install dependencies and build
+      run: |
+        npm ci
+        npm run build


### PR DESCRIPTION
#1 appears to put the lockfile into an invalid state, which was good impetus to have a workflow here that tests any commit builds successfully.